### PR TITLE
fix ToC link for "console-based applications"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
     * [Not based on any desktop environment](#not-based-on-any-desktop-environment)
     * [Third-party clients for online services](#third-party-clients-for-online-services)
     * [Package management and creation tools](#distro-based-package-management-tools)
-  * [Console-based Applications](#console-based-applications)
+  * [Console-based Applications and Tools](#console-based-applications-and-tools)
 * [Useful Websites](#useful-websites)
 * [License](#license)
 


### PR DESCRIPTION
I updated the table of contents' link to "console-based applications" because the new heading is named "Console-based Applications and Tools" and clicking the ToC entry did nothing.