### PR TITLE
Add Cloudsmith (a Package Management SaaS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,10 @@ Distro-independent:
 
 * [AppImageKit](https://github.com/probonopd/AppImageKit) - Using AppImageKit you can package applications in the [AppImage](http://appimage.org/) format that runs on common Linux-based operating systems, such as RHEL, CentOS, Ubuntu, Fedora, debian and derivatives; one app = one file.
 
+Repository hosting:
+
+* [Cloudsmith](https://cloudsmith.io) - A fully managed package management SaaS with support for Alpine Linux, Debian Linux and RedHat Linux (and many others); useful if you need to publicly or privately host Linux-based packages, or distribute them to world. Has a generous free tier and is also free for open-source.
+
 ### Console-based Applications and Tools
 
 You might also be interested in checking out [awesome-shell](https://github.com/alebcay/awesome-shell), [awesome-bash](https://github.com/awesome-lists/awesome-bash), [awesome-zsh-plugins](https://github.com/unixorn/awesome-zsh-plugins) or [awesome-fish](https://github.com/jbucaran/awesome-fish).


### PR DESCRIPTION
Hi! This PR adds a link to [Cloudsmith](https://cloudsmith.io), which is a package management service SaaS. It's commercial, but it is completely free for open-source and it has generous free tiers otherwise. It has first-class support for Alpine Linux, Debian Linux and RedHat Linux packages (and many other package formats, such as Python/Ruby), plus org/teams management, granular access controls, private repositories, repository-specific entitlements, a worldwide content distribution network, webhooks, access logs, etc. Thank you. :-)

*Full disclosure:* I work at Cloudsmith.