### PR TITLE
Update Fedora Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Distributions are organized into three different categories: for **beginners**, 
 
 > Fedora (formerly Fedora Core) is a Linux distribution developed by the community-supported Fedora Project and owned by Red Hat. Fedora contains software distributed under a free and open-source license and aims to be on the leading edge of such technologies. Fedora has a reputation for focusing on innovation, integrating new technologies early on and working closely with upstream Linux communities. The default desktop in Fedora is the GNOME desktop environment and the default interface is the GNOME Shell. Other desktop environments, including KDE, Xfce, LXDE, MATE and Cinnamon, are available. Fedora Project also distributes custom variations of Fedora called Fedora spins. These are built with specific sets of software packages, offering alternative desktop environments or targeting specific interests such as gaming, security, design, scientific computing and robotics.
 
-**Latest version:** Fedora Twenty Nine (29)
+**Latest version:** Fedora Thirty One (31)
 
 **Default Desktop Environment:** GNOME
 


### PR DESCRIPTION
Fedora 31 was planned to be released on October 22, 2019 however this has been pushed back to October 29, 2019. Merging can be held until the release target is met.